### PR TITLE
Reviewer Alex - Remove ExceptionHandler reference

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -51,8 +51,6 @@ TARGET_SOURCES := memcached_tap_client.cpp \
                   zmq_lvc.cpp \
                   astaire.cpp \
                   signalhandler.cpp \
-                  exception_handler.cpp \
-                  health_checker.cpp \
                   utils.cpp \
                   logger.cpp \
                   log.cpp \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,6 +277,7 @@ int main(int argc, char** argv)
   AstaireGlobalStatistics* global_stats = new AstaireGlobalStatistics(lvc);
   AstairePerConnectionStatistics* per_conn_stats = new AstairePerConnectionStatistics(lvc);
 
+  // Start Astaire last as this might cause a resync to happen synchronously.
   Astaire* astaire = new Astaire(view,
                                  view_cfg,
                                  astaire_resync_alarm,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,6 @@
  */
 
 #include "memcached_tap_client.hpp"
-#include "exception_handler.h"
 #include "astaire.hpp"
 #include "astaire_pd_definitions.hpp"
 #include "astaire_statistics.hpp"
@@ -166,7 +165,6 @@ int init_options(int argc, char**argv, struct options& options)
 }
 
 static sem_t term_sem;
-ExceptionHandler* exception_handler;
 
 // Signal handler that triggers astaire termination.
 void terminate_handler(int /*sig*/)
@@ -187,9 +185,6 @@ void signal_handler(int sig)
   // Ensure the log files are complete - the core file created by abort() below
   // will trigger the log files to be copied to the diags bundle
   LOG_COMMIT();
-
-  // Check if there's a stored jmp_buf on the thread and handle if there is
-  exception_handler->handle_exception();
 
   CL_ASTAIRE_CRASHED.log(strsignal(sig));
   closelog();


### PR DESCRIPTION
You missed my duck, admittedly I distracted you by initializing the term_sem in the exception handler, but, had you looked closer, you'd have seen that a few lines later I called a function on an uninitialized variable.  Good thing astaire never crashes :worried:.