### PR TITLE
[Reviewer: Andy] Miscellaneous live-test fixes

### DIFF
--- a/include/astaire_statistics.hpp
+++ b/include/astaire_statistics.hpp
@@ -47,7 +47,7 @@
 //
 // Gauge statistics hold values that count up and down and are reported
 // accurately (e.g. not gathered over a time period and analysed to make a
-// prepared value for reporting) hence we force a refresh whenver they are
+// prepared value for reporting) hence we force a refresh whenever they are
 // changed.
 #define GAUGE_STAT(NAME)                                                        \
   public:                                                                       \

--- a/include/astaire_statistics.hpp
+++ b/include/astaire_statistics.hpp
@@ -45,9 +45,10 @@
 
 // Macro for defining different statistics within a StatRecorder.
 //
-// Gauge statistics holds values that are reported accurately (e.g. not gathered
-// over a time period and analysed to make a prepared value for reporting) hence
-// we force a refresh whenver they are changed.
+// Gauge statistics hold values that count up and down and are reported
+// accurately (e.g. not gathered over a time period and analysed to make a
+// prepared value for reporting) hence we force a refresh whenver they are
+// changed.
 #define GAUGE_STAT(NAME)                                                        \
   public:                                                                       \
     void increment_##NAME(uint32_t delta) { _##NAME.fetch_add(delta);           \
@@ -58,9 +59,21 @@
     void set_##NAME(uint32_t val) { _##NAME.store(val); refresh(true); };       \
   private:                                                                      \
     std::atomic_uint_fast32_t _##NAME
-// Collated statistics are the opposite, they should only trigger reporting when
-// their prepared value has been calculated (e.g. after each time period) hence
-// we don't force the refreshed() call.
+// Counter statistics hold values that count up as events occur and are reported
+// accurately (e.g. not gathered over a time period and analysed to make a
+// prepared value for reporting).  Since they change frequently, we don't force a
+// refresh.
+#define COUNTER_STAT(NAME)                                                      \
+  public:                                                                       \
+    void increment_##NAME(uint32_t delta) { _##NAME.fetch_add(delta);           \
+                                            refresh(false); };                  \
+    void zero_##NAME() { _##NAME.store(0); refresh(false); };                   \
+    void set_##NAME(uint32_t val) { _##NAME.store(val); refresh(false); };      \
+  private:                                                                      \
+    std::atomic_uint_fast32_t _##NAME
+// Collated statistics should only trigger reporting when their prepared value
+// has been calculated (e.g. after each time period) hence we don't force the
+// refreshed() call.
 #define COLLATED_STAT(NAME)                                                     \
   public:                                                                       \
     void increment_##NAME(uint32_t delta) { _##NAME##_raw.fetch_add(delta);     \
@@ -121,9 +134,9 @@ public:
   void reset();
 
   GAUGE_STAT(total_buckets);
-  GAUGE_STAT(resynced_bucket_count);
-  GAUGE_STAT(resynced_keys_count);
-  GAUGE_STAT(resynced_bytes_count);
+  COUNTER_STAT(resynced_bucket_count);
+  COUNTER_STAT(resynced_keys_count);
+  COUNTER_STAT(resynced_bytes_count);
   COLLATED_STAT(bandwidth);
 
 private:
@@ -190,8 +203,8 @@ public:
     // Write the stats for this BucketRecord to the given vector.
     void write_out(std::vector<std::string>& vec);
 
-    GAUGE_STAT(resynced_keys_count);
-    GAUGE_STAT(resynced_bytes_count);
+    COUNTER_STAT(resynced_keys_count);
+    COUNTER_STAT(resynced_bytes_count);
     COLLATED_STAT(bandwidth);
 
 private:

--- a/src/astaire_statistics.cpp
+++ b/src/astaire_statistics.cpp
@@ -161,6 +161,7 @@ void AstairePerConnectionStatistics::read(uint_fast64_t period_us)
 
 void AstairePerConnectionStatistics::reset()
 {
+  _timestamp_us.store(get_timestamp_us());
   for (std::vector<ConnectionRecord*>::iterator it = _connections.begin();
        it != _connections.end();
        ++it)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,7 +210,10 @@ int main(int argc, char** argv)
   options.cluster_settings_file = "";
 
   boost::filesystem::path p = argv[0];
-  openlog(p.filename().c_str(), PDLOG_PID, PDLOG_LOCAL6);
+  // Copy the filename to a string so that we can be sure of its lifespan -
+  // the value passed to openlog must be valid for the duration of the program.
+  std::string filename = p.filename().c_str();
+  openlog(filename.c_str(), PDLOG_PID, PDLOG_LOCAL6);
   CL_ASTAIRE_STARTED.log();
 
   if (init_logging_options(argc, argv, options) != 0)


### PR DESCRIPTION
Andy,

Please can you review my live test fixes to Astaire?  This includes the following

*   running Astaire "nice-d" to ensure it never steals CPU from Sprout
*   waiting for 2s at the start of a "wait-sync" to ensure it doesn't think the process is already completed when actually it hasn't started yet
*   outputting the number of entries resynchronized as well as the ratio of buckets when reporting progress
*   fixing statistics to not report thousands of times a second and kill snmpd
*   initialize per-connection statistics' `timestamp_us` field correctly
*   setting the syslog process name correctly - I also need to fix this elsewhere, and that's tracked by https://github.com/Metaswitch/sprout/issues/973
*   doing a Get and Add or Replace rather than just an Add to close the window where memcached entries already exist locally from a previous iteration.

Thanks,

Matt