### PR TITLE
[Reviewer: Andy] Proactively restore memcached redundancy

### DIFF
--- a/debian/astaire.init.d
+++ b/debian/astaire.init.d
@@ -177,7 +177,7 @@ do_reload() {
         # restarting (for example, when it is sent a SIGHUP),
         # then implement that here.
         #
-        start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $EXECNAME
+        start-stop-daemon --stop --signal HUP --quiet --pidfile $PIDFILE --name $EXECNAME
         return 0
 }
 
@@ -218,6 +218,12 @@ do_wait_sync() {
                 echo -n ...
                 sleep 5
         done
+        return 0
+}
+
+do_full_resync() {
+        # Send Astaire SIGUSR1 to make it do a full resync.
+        start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE --name $EXECNAME
         return 0
 }
 
@@ -303,6 +309,10 @@ case "$1" in
   wait-sync)
         log_daemon_msg "Waiting for synchronization - $DESC" "$NAME"
         do_wait_sync
+        ;;
+  full-resync)
+        log_daemon_msg "Forcing full resync - $DESC" "$NAME"
+        do_full_resync
         ;;
   *)
         echo "Usage: $SCRIPTNAME {start|stop|status|restart|reload|force-reload|abort-restart|wait-sync}" >&2

--- a/include/astaire.hpp
+++ b/include/astaire.hpp
@@ -140,6 +140,11 @@ private:
   // @return - Whether the tagging was successful.
   bool tag_local_memcached();
 
+  // Untag the local memcached (so it is treated as being out-of-date).
+  //
+  // @return - Whether the untagging was successful.
+  bool untag_local_memcached();
+
   // Utility function for doing a request/response cycle to the local
   // memcached.
   //

--- a/include/astaire.hpp
+++ b/include/astaire.hpp
@@ -116,6 +116,11 @@ private:
   static uint16_t vbucket_for_key(const std::string& key);
   void handle_resync_triggers();
 
+  // Poll the local memcached instance to check if it is up-to-date or not
+  // (whether it has been running since the last resync completed).
+  enum PollResult { UP_TO_DATE, OUT_OF_DATE, ERROR };
+  PollResult poll_local_memcached();
+
   pthread_mutex_t _lock;
   pthread_cond_t _cv;
 

--- a/include/astaire.hpp
+++ b/include/astaire.hpp
@@ -97,7 +97,17 @@ public:
   static void* tap_buckets_thread(void* data);
 
 private:
-  OutstandingWorkList scaling_worklist();
+  // Do a resync operation.  Astaire will automatically calculate the TAPs
+  // required and process them to completion or failure.  This is safe to call
+  // when there's nothing to do.
+  //
+  // @param full_resync - Whether to do a full-resync (which streams all
+  //                      buckets into the local memcached from the replicas) or
+  //                      a minimal-resync (which only streams vbuckets that the
+  //                      local memcached does not already own).
+  void do_resync(bool full_resync);
+
+  OutstandingWorkList calculate_worklist(bool full_resync);
   void process_worklist(OutstandingWorkList& owl);
   TapList calculate_taps(const OutstandingWorkList& owl);
   bool perform_single_tap(const std::string& server,
@@ -110,16 +120,6 @@ private:
 
   static uint16_t vbucket_for_key(const std::string& key);
   void handle_resync_triggers();
-
-  // Do a resync operation.  Astaire will automatically calculate the TAPs
-  // required and process them to completion or failure.  This is safe to call
-  // when there's nothing to do.
-  //
-  // @param full_resync - Whether to do a full-resync (which streams all
-  //                      buckets into the local memcached from the replicas) or
-  //                      a minimal-resync (which only streams vbuckets that the
-  //                      local memcached does not already own).
-  void do_resync(bool full_resync);
 
   // Poll the local memcached instance to check if it is up-to-date or not
   // (whether it has been running since the last resync completed).

--- a/include/astaire.hpp
+++ b/include/astaire.hpp
@@ -122,8 +122,32 @@ private:
 
   // Poll the local memcached instance to check if it is up-to-date or not
   // (whether it has been running since the last resync completed).
+  //
+  // @return - One of PollResult.
   enum PollResult { UP_TO_DATE, OUT_OF_DATE, ERROR };
   PollResult poll_local_memcached();
+
+  // Tag the local memcached as being up-to-date.
+  //
+  // @return - Whether the tagging was successful.
+  bool tag_local_memcached();
+
+  // Utility function for doing a request/response cycle to the local
+  // memcached.
+  //
+  // @param req     - The request to send. The caller retains ownership.
+  // @param rsp_ptr - (out) The location to store a pointer to the received
+  //                  response. The caller gains ownership of the response and
+  //                  must delete it when they are finished with it. May be NULL
+  //                  meaning the response is not passed out.
+  //
+  // @return        - Whether a response of the right type has been received.
+  //
+  //                  Note that this does not reflect whether the request was
+  //                  actually successful, only whether we got the request to
+  //                  memcached and got a sensible looking response.
+  bool local_req_rsp(Memcached::BaseReq* req,
+                     Memcached::BaseRsp** rsp_ptr);
 
   pthread_mutex_t _lock;
   pthread_cond_t _cv;

--- a/include/astaire.hpp
+++ b/include/astaire.hpp
@@ -112,7 +112,7 @@ private:
 
   OutstandingWorkList calculate_worklist(bool full_resync);
   void process_worklist(OutstandingWorkList& owl);
-  TapList calculate_taps(const OutstandingWorkList& owl);
+  TapList calculate_taps(OutstandingWorkList& owl);
   bool perform_single_tap(const std::string& server,
                           const std::vector<uint16_t>& buckets,
                           pthread_t* handle);
@@ -123,6 +123,7 @@ private:
   static uint16_t vbucket_for_key(const std::string& key);
   void handle_resync_triggers();
   static int owl_total_buckets(const OutstandingWorkList& owl);
+  static bool owl_empty(const OutstandingWorkList& owl);
 
   // Update our local copy of the memcached store view.
   //

--- a/include/astaire.hpp
+++ b/include/astaire.hpp
@@ -116,7 +116,6 @@ private:
   bool complete_single_tap(pthread_t thread_id,
                            std::string& tap_server);
   void blacklist_server(OutstandingWorkList& owl, const std::string& server);
-  bool is_owl_valid(const OutstandingWorkList& owl);
 
   static uint16_t vbucket_for_key(const std::string& key);
   void handle_resync_triggers();

--- a/include/astaire.hpp
+++ b/include/astaire.hpp
@@ -91,6 +91,9 @@ public:
   // Reload the cluster config and kick off a new resync operation.
   void reload_config();
 
+  // TODO
+  void trigger_full_resync();
+
   // Static entry point for TAP threads.  The argument must be a valid
   // TapBucketsThreadData object.  Returns the same object with the `success`
   // field updated appropriately.
@@ -119,6 +122,11 @@ private:
 
   static uint16_t vbucket_for_key(const std::string& key);
   void handle_resync_triggers();
+
+  // Update our local copy of the memcached store view.
+  //
+  // @return - Whether the view was updated successfully.
+  bool update_view();
 
   // Poll the local memcached instance to check if it is up-to-date or not
   // (whether it has been running since the last resync completed).
@@ -155,11 +163,14 @@ private:
   pthread_t _control_thread;
   bool _terminated;
 
-  Updater<void, Astaire>* _updater;
+  Updater<void, Astaire>* _sighup_updater;
+  Updater<void, Astaire>* _sigusr1_updater;
 
   bool _view_updated;
   MemcachedStoreView* _view;
   MemcachedConfigReader* _view_cfg;
+
+  bool _full_resync_requested;
 
   Alarm* _alarm;
   AstaireGlobalStatistics* _global_stats;

--- a/include/astaire.hpp
+++ b/include/astaire.hpp
@@ -91,11 +91,6 @@ public:
   // Reload the cluster config and kick off a new resync operation.
   void reload_config();
 
-  // Do a resync operation.  Astaire will automatically calculate the TAPs
-  // required and process them to completion or failure.  This is safe to call
-  // when there's nothing to do.
-  void do_resync();
-
   // Static entry point for TAP threads.  The argument must be a valid
   // TapBucketsThreadData object.  Returns the same object with the `success`
   // field updated appropriately.
@@ -115,6 +110,16 @@ private:
 
   static uint16_t vbucket_for_key(const std::string& key);
   void handle_resync_triggers();
+
+  // Do a resync operation.  Astaire will automatically calculate the TAPs
+  // required and process them to completion or failure.  This is safe to call
+  // when there's nothing to do.
+  //
+  // @param full_resync - Whether to do a full-resync (which streams all
+  //                      buckets into the local memcached from the replicas) or
+  //                      a minimal-resync (which only streams vbuckets that the
+  //                      local memcached does not already own).
+  void do_resync(bool full_resync);
 
   // Poll the local memcached instance to check if it is up-to-date or not
   // (whether it has been running since the last resync completed).

--- a/include/astaire.hpp
+++ b/include/astaire.hpp
@@ -122,6 +122,7 @@ private:
 
   static uint16_t vbucket_for_key(const std::string& key);
   void handle_resync_triggers();
+  static int owl_total_buckets(const OutstandingWorkList& owl);
 
   // Update our local copy of the memcached store view.
   //

--- a/include/astaire_pd_definitions.hpp
+++ b/include/astaire_pd_definitions.hpp
@@ -100,7 +100,7 @@ const static PDLog CL_ASTAIRE_RESYNC_FAILED
   PDLOG_ERR,
   "Astaire has failed to synchronise some data.",
   "Astaire was unable to reach all the previous replicas for some data.",
-  "Not all data has been resynchronised, completing the scaling action now "
+  "Not all data has been resynchronised. Completing a resize operation now "
     "may result in loss of data or loss of redundancy",
   "Check the status of the memcached cluster and ensure network connectivity "
     "is possible between all nodes."
@@ -111,11 +111,14 @@ const static PDLog CL_ASTAIRE_START_RESYNC
   PDLog::CL_ASTAIRE_ID + 6,
   PDLOG_INFO,
   "Astaire has started a resync operation",
-  "Astaire has detected an on-going cluster resize and is proactively "
-    "resynchronising data between cluster members.",
+  "Astaire is proactively resynchronising data between cluster members."
+    "This could be because:"
+    "(1). Astaire has detected that the cluster is being resized."
+    "(2). Astaire has detected the local Memcached process has been restarted."
+    "(3). An operator has manually triggered a resync.",
   "Data is being resynced across the Memcached cluster.",
   "Wait until the current resync operation has completed before continuing "
-    "with the cluster resize."
+    "with any cluster resize."
 );
 
 const static PDLog CL_ASTAIRE_COMPLETE_RESYNC
@@ -124,9 +127,9 @@ const static PDLog CL_ASTAIRE_COMPLETE_RESYNC
   PDLOG_INFO,
   "Astaire has completed a resync operation",
   "Astaire has synchronised all available data to the local node.",
-  "The scale operation may be completed once all other Astaire instances have "
-    "completed their resync operations.",
-  "Once all other Astaire instances have completed their resync operations "
-    "you may conrinue the cluster resize"
+  "If the cluster is being resized, this operation can be completed once all other "
+    "Astaire instances have completed their resync operations.",
+  "If the cluster is being resized, you may continue the resize operation once "
+    "all other Astaire instances have completed their resync operations."
 );
 #endif

--- a/include/memcached_tap_client.hpp
+++ b/include/memcached_tap_client.hpp
@@ -89,6 +89,7 @@ namespace Memcached
     SET = 0x01,
     ADD = 0x02,
     REPLACE = 0x03,
+    DELETE = 0x04,
     TAP_CONNECT = 0x40,
     TAP_MUTATE = 0x41,
     SET_VBUCKET = 0x3d
@@ -239,6 +240,18 @@ namespace Memcached
   private:
     std::string _value;
     uint32_t _flags;
+  };
+
+  class DeleteReq : public BaseReq
+  {
+  public:
+    DeleteReq(std::string key) : BaseReq((uint8_t)OpCode::DELETE, key, 0, 0, 0) {}
+  };
+
+  class DeleteRsp : public BaseRsp
+  {
+  public:
+    DeleteRsp(const std::string& msg);
   };
 
   class SetAddReplaceReq : public BaseReq

--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -39,7 +39,8 @@
 #include "astaire_pd_definitions.hpp"
 #include <algorithm>
 
-const std::string ASTAIRE_TAG_KEY = "astaire\\tag";
+const std::string ASTAIRE_KEY_PREFIX = "astaire\\";
+const std::string ASTAIRE_TAG_KEY = ASTAIRE_KEY_PREFIX + "tag";
 const std::string ASTAIRE_TAG_VALUE = "{}";
 
 // Utility function to search a vector.
@@ -226,6 +227,10 @@ void* Astaire::tap_buckets_thread(void *data)
         if (iter == tap_data->buckets.end())
         {
           LOG_DEBUG("Disarding TAP_MUTATE for incorrect vBucket");
+        }
+        else if (mutate->key().find(ASTAIRE_KEY_PREFIX) == 0)
+        {
+          LOG_DEBUG("Disarding TAP_MUTATE for Astaire tag record");
         }
         else
         {

--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -683,7 +683,7 @@ void Astaire::do_resync(bool full_resync)
     return;
   }
 
-  _global_stats->set_total_buckets(owl.size());
+  _global_stats->set_total_buckets(owl_total_buckets(owl));
 
   CL_ASTAIRE_START_RESYNC.log();
   if (_alarm)
@@ -701,6 +701,20 @@ void Astaire::do_resync(bool full_resync)
 
   _global_stats->reset();
   _per_conn_stats->reset();
+}
+
+int Astaire::owl_total_buckets(const OutstandingWorkList& owl)
+{
+  int buckets = 0;
+
+  for (OutstandingWorkList::const_iterator it = owl.begin();
+       it != owl.end();
+       ++it)
+  {
+    buckets += it->second.size();
+  }
+
+  return buckets;
 }
 
 // Poll the local memcached to check if it is up-to-date.

--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -40,7 +40,7 @@
 #include <algorithm>
 #include <set>
 
-const std::string ASTAIRE_KEY_PREFIX = "astaire\\";
+const std::string ASTAIRE_KEY_PREFIX = "astaire\\\\";
 const std::string ASTAIRE_TAG_KEY = ASTAIRE_KEY_PREFIX + "tag";
 const std::string ASTAIRE_TAG_VALUE = "{}";
 

--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -658,8 +658,13 @@ void Astaire::handle_resync_triggers()
     }
     else
     {
+      // Wait 10s for a resync trigger. If we don't get one in that time we
+      // wake up and poll memcached again.
       LOG_DEBUG("Wait for resync trigger");
-      pthread_cond_wait(&_cv, &_lock);
+      struct timespec ts;
+      clock_gettime(CLOCK_MONOTONIC, &ts);
+      ts.tv_sec += 10;
+      pthread_cond_timedwait(&_cv, &_lock, &ts);
     }
   }
 

--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -428,7 +428,7 @@ void* Astaire::tap_buckets_thread(void *data)
 
   if (tap_data->success)
   {
-    tap_data->global_stats->set_resynced_bucket_count(tap_data->buckets.size());
+    tap_data->global_stats->increment_resynced_bucket_count(tap_data->buckets.size());
     tap_data->conn_stats->lock();
     tap_data->conn_stats->set_resynced_bucket_count(tap_data->buckets.size());
     tap_data->conn_stats->unlock();

--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -638,6 +638,10 @@ void Astaire::handle_resync_triggers()
       _full_resync_requested = false;
       resync = true;
       full_resync = true;
+
+      // Mark the local memcached as out-of-date. This means if we crash during
+      // the resync we will restart it when we come back.
+      untag_local_memcached();
     }
 
     PollResult res = poll_local_memcached();
@@ -751,6 +755,11 @@ bool Astaire::tag_local_memcached()
   return local_req_rsp(&set_req, NULL);
 }
 
+bool Astaire::untag_local_memcached()
+{
+  Memcached::DeleteReq del_req(ASTAIRE_TAG_KEY);
+  return local_req_rsp(&del_req, NULL);
+}
 
 bool Astaire::local_req_rsp(Memcached::BaseReq* req,
                             Memcached::BaseRsp** rsp_ptr)

--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -176,7 +176,7 @@ void Astaire::control_thread()
     }
 
     PollResult res = poll_local_memcached();
-    if (res != UP_TO_DATE)
+    if (res == OUT_OF_DATE)
     {
       LOG_DEBUG("Local memcached is not up-to-date - full resync required");
       resync = true;

--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -85,11 +85,12 @@ Astaire::Astaire(MemcachedStoreView* view,
   _sighup_updater = new Updater<void, Astaire>(this,
                                                std::mem_fun(&Astaire::reload_config));
 
-  // Start the updater to handle SIGUSR1s
-#if 0
+  // Start the updater to handle SIGUSR1s. Don't run this updater right away,
+  // as this would trigger a full resync whenever Astaire starts up!
   _sigusr1_updater = new Updater<void, Astaire>(this,
-                                                std::mem_fun(&Astaire::trigger_full_resync));
-#endif
+                                                std::mem_fun(&Astaire::trigger_full_resync),
+                                                &_sigusr1_handler,
+                                                false);
 }
 
 Astaire::~Astaire()


### PR DESCRIPTION
Please can you review this PR to enhance Astaire to pro-actively restore redundancy when a memcached server restarts. This also fixes some edge cases where data could be lost on a scaling operation if one of the current servers had recently restarted. 

The code should match the design we discussed. Specifically I have:

* Refactored the code to use a new "control thread" that periodically polls the local memcached server to see if it has restarted, and can also be kicked by the signal handlers.
* Changed the work-list processing so that Astaire streams vbuckets from all replicas, not just one of them. The resync is only considered as failed if a vbucket could not be streamed from any replica. 
* Added code to tag (and un-tag) the memcached server as being up-to-date. 
* Modified the ENT log test to reflect that resync is not always caused by scaling. The alarm text was already general enough that no change was needed to https://github.com/Metaswitch/cpp-common/blob/master/src/alarmdefinition.cpp.

I have not tested this at all yet. Astaire has no UTs, and I wanted to get it reviewed before I start doing non-regressible live testing. 