### PR TITLE
Prevent tight loop if memcached restarts and there is no work to do

### DIFF
--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -186,6 +186,12 @@ void Astaire::control_thread()
     if (resync)
     {
       do_resync(full_resync);
+
+      // Tag the local memcached to mark it as up-to-date, even if the resync
+      // failed. The most likely cause for a failure is that all the replicas for
+      // some vbuckets are down which means the bucket's data has been lost and
+      // there is no point in trying to resync it again.
+      tag_local_memcached();
     }
     else
     {
@@ -612,12 +618,6 @@ void Astaire::process_worklist(OutstandingWorkList& owl)
       }
     }
   }
-
-  // Tag the local memcached to mark it as up-to-date, even if the resync
-  // failed. The most likely cause for a failure is that all the replicas for
-  // some vbuckets are down which means the bucket's data has been lost and
-  // there is no point in trying to resync it again.
-  tag_local_memcached();
 
   if (unstreamed_buckets.empty())
   {


### PR DESCRIPTION
Spotted a bug where if you have a single memcached cluster and memcached restarts, Astaire will get into a loop where it:

1. Spots its tag is missing and a resync is required. 
2. Calculates the worklist and realises there is nothing to do. It does not add its tag at this point.
3. Goto 1

Fixed by making Astaire tag memcached whenever it starts a resync, not just when it processes a worklist.

@bossmc has reviewed