### PR TITLE
[Reviewer: Andy] Only add a vbucket to the worklist if there are replicas to stream it from

### DIFF
--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -538,8 +538,8 @@ Astaire::OutstandingWorkList Astaire::calculate_worklist(bool full_resync)
       }
 
       // If we do not already have the vbucket we need to stream from the other
-      // replicas.
-      if (!is_in_vector(source_replicas, _self))
+      // replicas (assuming there are any).
+      if (!source_replicas.empty() && !is_in_vector(source_replicas, _self))
       {
         LOG_DEBUG("Stream vbucket %d from %d replicas",
                   vbucket, source_replicas.size());


### PR DESCRIPTION
Andy please can you review this PR that fixes #11. 

Tested by spinning up an AIO node and checking (using syslog) that Astaire did not do a resync in any of the following scenarios:

* Memcached restarted
* Astaire restarted
* `sudo service astaire reload`
* `sudo service astaire full-resync`