### PR TITLE
[Reviewer: Andy] Tell dpkg not to start astaire

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,6 +26,10 @@ override_dh_auto_test:
 override_dh_auto_install:
 	mkdir debian/tmp
 
+# Don't start - monit does that for us.
+override_dh_installinit:
+	dh_installinit --no-start -u"defaults 60 40"
+
 override_dh_shlibdeps:
 override_dh_strip:
 	dh_strip -pastaire --dbg-package=astaire-dbg


### PR DESCRIPTION
This PR fixes #14 by making dpkg not start astaire. The options are the same as passed to sprout. 

Tested by upgrading astaire to a version with the fix and checking that it did not crash over the upgrade. 