### PR TITLE
[Reviewer: Andy] Astaire stress test fixes

### DIFF
--- a/debian/astaire.postinst
+++ b/debian/astaire.postinst
@@ -86,6 +86,12 @@ case "$1" in
         setup_logging
         [ ! -x /usr/share/clearwater/bin/clearwater-logging-update ] || /usr/share/clearwater/bin/clearwater-logging-update
         add_section /etc/security/limits.conf astaire /etc/security/limits.conf.astaire
+
+        # Start the service to throttle astaire (to prevent it using too much
+        # CPU). `start` will not create a new instance if it is already
+        # running (though it does return non-0 in this scenario).
+        start astaire-throttle || /bin/true
+
         /usr/share/clearwater/infrastructure/scripts/astaire.monit
 
         # Restart astaire.  Always do this by terminating astaire so monit will

--- a/debian/astaire.prerm
+++ b/debian/astaire.prerm
@@ -82,7 +82,7 @@ case "$1" in
         service $NAME stop || true
 
         # Also stop the astaire throttling service.
-        stop astaire-throttle
+        stop astaire-throttle || true
 
         if [ $1 != "upgrade" ]; then
             # We shouldn't do this cleanup on upgrade - deleting the

--- a/debian/astaire.prerm
+++ b/debian/astaire.prerm
@@ -80,6 +80,10 @@ case "$1" in
         rm -f /etc/monit/conf.d/$NAME.monit
         reload clearwater-monit &> /dev/null || true
         service $NAME stop || true
+
+        # Also stop the astaire throttling service.
+        stop astaire-throttle
+
         if [ $1 != "upgrade" ]; then
             # We shouldn't do this cleanup on upgrade - deleting the
             # logs loses valuable information

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Homepage: http://projectclearwater.org/
 Package: astaire
 Architecture: any
 Recommends: memcached, clearwater-memcached, clearwater-snmp-handler-astaire
-Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, libzmq3, astaire-libs
+Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, libzmq3, astaire-libs, cpulimit
 Suggests: astaire-dbg
 Description: Astaire, active resynchronisation for memcached clusters
 

--- a/include/memcached_tap_client.hpp
+++ b/include/memcached_tap_client.hpp
@@ -318,7 +318,7 @@ namespace Memcached
                uint64_t cas,
                uint32_t flags,
                uint32_t expiry) :
-      SetAddReplaceReq((uint8_t)OpCode::SET, key, vbucket, value, cas, flags, expiry)
+      SetAddReplaceReq((uint8_t)OpCode::REPLACE, key, vbucket, value, cas, flags, expiry)
     {}
   };
 

--- a/root/etc/init/astaire-throttle.conf
+++ b/root/etc/init/astaire-throttle.conf
@@ -1,0 +1,24 @@
+# astaire-throttle
+#
+# A service that prevents astaire from using up too much CPU.
+
+description "Astaire throttling service"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+script
+  # Clearwater nodes should have at least 20% CPU headroom for management / #
+  # orchestration actions. By default we give astaire 5% of the CPU. Assuming
+  # memcached's # CPU usage is similar this means resyncing doesn't use more
+  # than 10% of the # CPU, which is well within the recommended headroom.
+  astaire_cpu_limit_percentage=5
+  . /etc/clearwater/config
+
+  # Because of the way cpulimit works we have to scale the system-wide limit by
+  # the number of cores.
+  num_cpus=`grep '^processor' /proc/cpuinfo | wc -l`
+  cpulimit -e astaire -l `expr $num_cpus \* $astaire_cpu_limit_percentage`
+end script

--- a/root/etc/init/astaire-throttle.conf
+++ b/root/etc/init/astaire-throttle.conf
@@ -10,11 +10,13 @@ stop on runlevel [!2345]
 respawn
 
 script
-  # Clearwater nodes should have at least 20% CPU headroom for management / #
+  # Clearwater nodes should have at least 20% CPU headroom for management /
   # orchestration actions. By default we give astaire 5% of the CPU. Assuming
-  # memcached's # CPU usage is similar this means resyncing doesn't use more
-  # than 10% of the # CPU, which is well within the recommended headroom.
+  # memcached's CPU usage is similar this means resyncing doesn't use more
+  # than 10% of the CPU, which is well within the recommended headroom.
   astaire_cpu_limit_percentage=5
+
+  # Source clearwater config (to allow the CPU limit to be overridden).
   . /etc/clearwater/config
 
   # Because of the way cpulimit works we have to scale the system-wide limit by

--- a/src/memcached_tap_client.cpp
+++ b/src/memcached_tap_client.cpp
@@ -401,7 +401,7 @@ Memcached::Status Memcached::Connection::recv(Memcached::BaseMessage** msg)
     return Memcached::Status::DISCONNECTED;
   }
 
-  static const int BUFLEN = 128;
+  static const int BUFLEN = 16 * 1024;
   char buf[BUFLEN];
   ssize_t recv_size = 0;
 


### PR DESCRIPTION
This PR contains the following fixes:

* Add an `astaire-throttle` service that limits astaire's CPU usage with `cpulimit`.
* Make the connection object use a bigger read buffer (to reduce the number of read calls we need to make). This gives a small perf improvement. 
* Fix The opcode for the `ReplaceReq` object.

All tested as part of my astaire stress testing. I've also done some more functional testing of the astaire-throttle service:
* Upgrade astaire to a version containing the service. It was started automatically. 
* Reboot the machine. Service is started automatically. 
* Kicked off a full resync by killing memcached. Top showed astaire was limited to the correct ammount of CPU. 
* Change the config option and restart the service. `ps` showed the change had been picked up. 

I will document the new config option in [readthedocs](https://github.com/Metaswitch/clearwater-readthedocs/blob/master/docs/Clearwater_Configuration_Options_Reference.md) as an advanced option. 