### PR TITLE
Set namespace prefix for multiple network support (fixed issue #19)

### DIFF
--- a/debian/astaire.init.d
+++ b/debian/astaire.init.d
@@ -86,6 +86,7 @@ get_settings()
         # Set up defaults for user settings then pull in any overrides.
         log_level=2
         [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
+        [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
 }
 
 #


### PR DESCRIPTION
Added setting of namespace_prefix to support multiple networks.