### PR TITLE
Reviewer AMC: Remove unsupported test targets from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,10 @@ include ${MK_DIR}/astaire.mk
 
 build: ${SUBMODULES} astaire
 
-test: ${SUBMODULES} astaire_test
+# Deliberately disabling test targets until UTs are written for Astaire
+#test: ${SUBMODULES} astaire_test
 
-testall: $(patsubst %, %_test, ${SUBMODULES}) test
+#testall: $(patsubst %, %_test, ${SUBMODULES}) test
 
 clean: $(patsubst %, %_clean, ${SUBMODULES}) astaire_clean
 	rm -rf ${ROOT}/usr

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,11 +37,12 @@ all: stage-build
 ROOT := $(abspath $(shell pwd)/../)
 MK_DIR := ${ROOT}/mk
 
-GTEST_DIR := $(ROOT)/modules/gmock/gtest
-GMOCK_DIR := $(ROOT)/modules/gmock
+# Disabling all test related targets as Astaire currently has no UTs
+#GTEST_DIR := $(ROOT)/modules/gmock/gtest
+#GMOCK_DIR := $(ROOT)/modules/gmock
 
 TARGET := astaire
-TARGET_TEST := astaire_test
+#TARGET_TEST := astaire_test
 
 TARGET_SOURCES := memcached_tap_client.cpp \
                   memcached_config.cpp \
@@ -58,28 +59,28 @@ TARGET_SOURCES := memcached_tap_client.cpp \
 
 TARGET_SOURCES_BUILD := main.cpp
 
-TARGET_SOURCES_TEST := main.cpp
+#TARGET_SOURCES_TEST := main.cpp
 
-TARGET_EXTRA_OBJS_TEST := gmock-all.o \
-                          gtest-all.o
+#TARGET_EXTRA_OBJS_TEST := gmock-all.o \
+#                          gtest-all.o
+ 
+#TEST_XML = $(TEST_OUT_DIR)/test_detail_$(TARGET_TEST).xml
+#COVERAGE_XML = $(TEST_OUT_DIR)/coverage_$(TARGET_TEST).xml
+#COVERAGE_LIST_TMP = $(TEST_OUT_DIR)/coverage_list_tmp
+#COVERAGE_LIST = $(TEST_OUT_DIR)/coverage_list
+#COVERAGE_MASTER_LIST = ut/coverage-not-yet
+#VG_XML = $(TEST_OUT_DIR)/vg_$(TARGET_TEST).memcheck
+#VG_OUT = $(TEST_OUT_DIR)/vg_$(TARGET_TEST).txt
+#VG_LIST = $(TEST_OUT_DIR)/vg_$(TARGET_TEST)_list
 
-TEST_XML = $(TEST_OUT_DIR)/test_detail_$(TARGET_TEST).xml
-COVERAGE_XML = $(TEST_OUT_DIR)/coverage_$(TARGET_TEST).xml
-COVERAGE_LIST_TMP = $(TEST_OUT_DIR)/coverage_list_tmp
-COVERAGE_LIST = $(TEST_OUT_DIR)/coverage_list
-COVERAGE_MASTER_LIST = ut/coverage-not-yet
-VG_XML = $(TEST_OUT_DIR)/vg_$(TARGET_TEST).memcheck
-VG_OUT = $(TEST_OUT_DIR)/vg_$(TARGET_TEST).txt
-VG_LIST = $(TEST_OUT_DIR)/vg_$(TARGET_TEST)_list
+#VG_SUPPRESS = ut/$(TARGET_TEST).supp
 
-VG_SUPPRESS = ut/$(TARGET_TEST).supp
-
-EXTRA_CLEANS += $(TEST_XML) \
-                $(COVERAGE_XML) \
-                $(VG_XML) $(VG_OUT) \
-                $(OBJ_DIR_TEST)/*.gcno \
-                $(OBJ_DIR_TEST)/*.gcda \
-                *.gcov
+#EXTRA_CLEANS += $(TEST_XML) \
+#                $(COVERAGE_XML) \
+#                $(VG_XML) $(VG_OUT) \
+#                $(OBJ_DIR_TEST)/*.gcno \
+#                $(OBJ_DIR_TEST)/*.gcda \
+#                *.gcov
 
 CPPFLAGS += -Wno-write-strings \
             -ggdb3 -gdwarf-2 -std=c++0x
@@ -103,11 +104,11 @@ CPPFLAGS_BUILD += -O2
 # Disable optimization, for speed and coverage accuracy.
 # Allow testing of private and protected fields/methods.
 # Add the Google Mock / Google Test includes.
-CPPFLAGS_TEST  += -DUNIT_TEST \
-                  -fprofile-arcs -ftest-coverage \
-                  -O0 \
-                  -fno-access-control \
-                  -I$(GTEST_DIR)/include -I$(GMOCK_DIR)/include
+#CPPFLAGS_TEST  += -DUNIT_TEST \
+#                  -fprofile-arcs -ftest-coverage \
+#                  -O0 \
+#                  -fno-access-control \
+#                  -I$(GTEST_DIR)/include -I$(GMOCK_DIR)/include
 
 LDFLAGS += -L${ROOT}/usr/lib
 LDFLAGS += -lmemcached \
@@ -118,35 +119,35 @@ LDFLAGS += -lmemcached \
            -lzmq
 
 # Test build uses just-built libraries, which may not be installed
-LDFLAGS_TEST += -Wl,-rpath=$(ROOT)/usr/lib
+#LDFLAGS_TEST += -Wl,-rpath=$(ROOT)/usr/lib
 
 # Now the GMock / GTest boilerplate.
-GTEST_HEADERS := $(GTEST_DIR)/include/gtest/*.h \
-                 $(GTEST_DIR)/include/gtest/internal/*.h
-GMOCK_HEADERS := $(GMOCK_DIR)/include/gmock/*.h \
-                 $(GMOCK_DIR)/include/gmock/internal/*.h \
-                 $(GTEST_HEADERS)
+#GTEST_HEADERS := $(GTEST_DIR)/include/gtest/*.h \
+#                 $(GTEST_DIR)/include/gtest/internal/*.h
+#GMOCK_HEADERS := $(GMOCK_DIR)/include/gmock/*.h \
+#                 $(GMOCK_DIR)/include/gmock/internal/*.h \
+#                 $(GTEST_HEADERS)
 
-GTEST_SRCS_ := $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
-GMOCK_SRCS_ := $(GMOCK_DIR)/src/*.cc $(GMOCK_HEADERS)
+#GTEST_SRCS_ := $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
+#GMOCK_SRCS_ := $(GMOCK_DIR)/src/*.cc $(GMOCK_HEADERS)
 # End of boilerplate
 
 COVERAGEFLAGS = $(OBJ_DIR_TEST) --object-directory=$(shell pwd) --root=${ROOT} \
                 --exclude='(^include/|^modules/gmock/|^modules/rapidjson/|^modules/cpp-common/include/|^modules/cpp-common/test_utils|^ut/|^usr/)' \
                 --sort-percentage
 
-VGFLAGS = --suppressions=$(VG_SUPPRESS) \
-          --gen-suppressions=all \
-          --leak-check=full \
-          --track-origins=yes \
-          --malloc-fill=cc \
-          --free-fill=df
+#VGFLAGS = --suppressions=$(VG_SUPPRESS) \
+#          --gen-suppressions=all \
+#          --leak-check=full \
+#          --track-origins=yes \
+#          --malloc-fill=cc \
+#          --free-fill=df
 
 # Define JUSTTEST=<testname> to test just that test.  Easier than
 # passing the --gtest_filter in EXTRA_TEST_ARGS.
-ifdef JUSTTEST
-  EXTRA_TEST_ARGS ?= --gtest_filter=*$(JUSTTEST)*
-endif
+#ifdef JUSTTEST
+#  EXTRA_TEST_ARGS ?= --gtest_filter=*$(JUSTTEST)*
+#endif
 
 build: ${ROOT}/usr/include/astaire_alarmdefinition.h
 
@@ -156,8 +157,8 @@ include ${ROOT}/modules/cpp-common/makefiles/alarm-utils.mk
 .PHONY: stage-build
 stage-build: build
 
-.PHONY: test
-test: run_test coverage vg coverage-check vg-check
+#.PHONY: test
+#test: run_test coverage vg coverage-check vg-check
 
 # Run the test.  You can set EXTRA_TEST_ARGS to pass extra arguments
 # to the test, e.g.,
@@ -167,46 +168,46 @@ test: run_test coverage vg coverage-check vg-check
 # runs just the StatefulProxyTest tests.
 #
 # Ignore failure here; it will be detected by Jenkins.
-.PHONY: run_test
-run_test: build_test | $(TEST_OUT_DIR)
-	rm -f $(TEST_XML)
-	rm -f $(OBJ_DIR_TEST)/*.gcda
-	$(TARGET_BIN_TEST) $(EXTRA_TEST_ARGS) --gtest_output=xml:$(TEST_XML)
+#.PHONY: run_test
+#run_test: build_test | $(TEST_OUT_DIR)
+#	rm -f $(TEST_XML)
+#	rm -f $(OBJ_DIR_TEST)/*.gcda
+#	$(TARGET_BIN_TEST) $(EXTRA_TEST_ARGS) --gtest_output=xml:$(TEST_XML)
 
-.PHONY: coverage
-coverage: | $(TEST_OUT_DIR)
-	$(GCOVR) $(COVERAGEFLAGS) --xml > $(COVERAGE_XML)
+#.PHONY: coverage
+#coverage: | $(TEST_OUT_DIR)
+#	$(GCOVR) $(COVERAGEFLAGS) --xml > $(COVERAGE_XML)
 
 # Check that we have 100% coverage of all files except those that we
 # have declared we're being relaxed on.  In particular, all new files
 # must have 100% coverage or be added to $(COVERAGE_MASTER_LIST).
 # The string "Marking build unstable" is recognised by the CI scripts
 # and if it is found the build is marked unstable.
-.PHONY: coverage-check
-coverage-check: coverage
-	@xmllint --xpath '//class[@line-rate!="1.0"]/@filename' $(COVERAGE_XML) \
-		| tr ' ' '\n' \
-		| grep filename= \
-		| cut -d\" -f2 \
-		| sort > $(COVERAGE_LIST_TMP)
-	@sort $(COVERAGE_MASTER_LIST) | comm -23 $(COVERAGE_LIST_TMP) - > $(COVERAGE_LIST)
-	@if grep -q ^ $(COVERAGE_LIST) ; then \
-		echo "Error: some files unexpectedly have less than 100% code coverage:" ; \
-		cat $(COVERAGE_LIST) ; \
-		/bin/false ; \
-		echo "Marking build unstable." ; \
-	fi
+#.PHONY: coverage-check
+#coverage-check: coverage
+#	@xmllint --xpath '//class[@line-rate!="1.0"]/@filename' $(COVERAGE_XML) \
+#		| tr ' ' '\n' \
+#		| grep filename= \
+#		| cut -d\" -f2 \
+#		| sort > $(COVERAGE_LIST_TMP)
+#	@sort $(COVERAGE_MASTER_LIST) | comm -23 $(COVERAGE_LIST_TMP) - > $(COVERAGE_LIST)
+#	@if grep -q ^ $(COVERAGE_LIST) ; then \
+#		echo "Error: some files unexpectedly have less than 100% code coverage:" ; \
+#		cat $(COVERAGE_LIST) ; \
+#		/bin/false ; \
+#		echo "Marking build unstable." ; \
+#	fi
 
 # Get quick coverage data at the command line. Add --branches to get branch info
 # instead of line info in report.  *.gcov files generated in current directory
 # if you need to see full detail.
-.PHONY: coverage_raw
-coverage_raw: | $(TEST_OUT_DIR)
-	$(GCOVR) $(COVERAGEFLAGS) --keep
+#.PHONY: coverage_raw
+#coverage_raw: | $(TEST_OUT_DIR)
+#	$(GCOVR) $(COVERAGEFLAGS) --keep
 
-.PHONY: debug
-debug: build_test
-	gdb --args $(TARGET_BIN_TEST) $(EXTRA_TEST_ARGS)
+#.PHONY: debug
+#debug: build_test
+#	gdb --args $(TARGET_BIN_TEST) $(EXTRA_TEST_ARGS)
 
 # Don't run VG against death tests; they don't play nicely.
 # Be aware that running this will count towards coverage.
@@ -214,31 +215,31 @@ debug: build_test
 # unit-test run earlier.
 # Test failure should not lead to build failure - instead we observe
 # test failure from Jenkins.
-.PHONY: vg
-vg: build_test | $(TEST_OUT_DIR)
-	-valgrind --xml=yes --xml-file=$(VG_XML) $(VGFLAGS) \
-	  $(TARGET_BIN_TEST) --gtest_filter='-*DeathTest*' $(EXTRA_TEST_ARGS) > $(VG_OUT) 2>&1
+#.PHONY: vg
+#vg: build_test | $(TEST_OUT_DIR)
+#	-valgrind --xml=yes --xml-file=$(VG_XML) $(VGFLAGS) \
+#	  $(TARGET_BIN_TEST) --gtest_filter='-*DeathTest*' $(EXTRA_TEST_ARGS) > $(VG_OUT) 2>&1
 
 # Check whether there were any errors from valgrind. Output to screen any errors found,
 # and details of where to find the full logs.
 # The output file will contain <error><kind>ERROR</kind></error>, or 'XPath set is empty'
 # if there are no errors.
-.PHONY: vg-check
-vg-check: vg
-	@xmllint --xpath '//error/kind' $(VG_XML) 2>&1 | \
-		sed -e 's#<kind>##g' | \
-		sed -e 's#</kind>#\n#g' | \
-		sort > $(VG_LIST)
-	@if grep -q -v "XPath set is empty" $(VG_LIST) ; then \
-		echo "Error: some memory errors have been detected" ; \
-		cat $(VG_LIST) ; \
-		echo "See $(VG_XML) for further details." ; \
-	fi
+#.PHONY: vg-check
+#vg-check: vg
+#	@xmllint --xpath '//error/kind' $(VG_XML) 2>&1 | \
+#		sed -e 's#<kind>##g' | \
+#		sed -e 's#</kind>#\n#g' | \
+#		sort > $(VG_LIST)
+#	@if grep -q -v "XPath set is empty" $(VG_LIST) ; then \
+#		echo "Error: some memory errors have been detected" ; \
+#		cat $(VG_LIST) ; \
+#		echo "See $(VG_XML) for further details." ; \
+#	fi
 
-.PHONY: vg_raw
-vg_raw: build_test | $(TEST_OUT_DIR)
-	-valgrind --gen-suppressions=all $(VGFLAGS) \
-	  $(TARGET_BIN_TEST) --gtest_filter='-*DeathTest*' $(EXTRA_TEST_ARGS)
+#.PHONY: vg_raw
+#vg_raw: build_test | $(TEST_OUT_DIR)
+#	-valgrind --gen-suppressions=all $(VGFLAGS) \
+#	  $(TARGET_BIN_TEST) --gtest_filter='-*DeathTest*' $(EXTRA_TEST_ARGS)
 
 .PHONY: distclean
 distclean: clean
@@ -248,14 +249,14 @@ ${ROOT}/usr/include/astaire_alarmdefinition.h : ${BUILD_DIR}/bin/alarm_header ${
 	mv astaire_alarmdefinition.h $@
 
 # Build rules for GMock/GTest library.
-$(OBJ_DIR_TEST)/gtest-all.o : $(GTEST_SRCS_)
-	$(CXX) $(CPPFLAGS) -I$(GTEST_DIR) -I$(GTEST_DIR)/include -I$(GMOCK_DIR) -I$(GMOCK_DIR)/include \
-            -c $(GTEST_DIR)/src/gtest-all.cc -o $@
+#$(OBJ_DIR_TEST)/gtest-all.o : $(GTEST_SRCS_)
+#	$(CXX) $(CPPFLAGS) -I$(GTEST_DIR) -I$(GTEST_DIR)/include -I$(GMOCK_DIR) -I$(GMOCK_DIR)/include \
+#            -c $(GTEST_DIR)/src/gtest-all.cc -o $@
 
-$(OBJ_DIR_TEST)/gmock-all.o : $(GMOCK_SRCS_)
-	$(CXX) $(CPPFLAGS) -I$(GTEST_DIR) -I$(GTEST_DIR)/include -I$(GMOCK_DIR) -I$(GMOCK_DIR)/include \
-            -c $(GMOCK_DIR)/src/gmock-all.cc -o $@
+#$(OBJ_DIR_TEST)/gmock-all.o : $(GMOCK_SRCS_)
+#	$(CXX) $(CPPFLAGS) -I$(GTEST_DIR) -I$(GTEST_DIR)/include -I$(GMOCK_DIR) -I$(GMOCK_DIR)/include \
+#            -c $(GMOCK_DIR)/src/gmock-all.cc -o $@
 
 # Build rule for our interposer.
-$(OBJ_DIR_TEST)/test_interposer.so: ut/test_interposer.cpp ut/test_interposer.hpp
-	$(CXX) $(CPPFLAGS) -shared -fPIC -ldl $< -o $@
+#$(OBJ_DIR_TEST)/test_interposer.so: ut/test_interposer.cpp ut/test_interposer.hpp
+#	$(CXX) $(CPPFLAGS) -shared -fPIC -ldl $< -o $@


### PR DESCRIPTION
In order to avoid confusion when "make test" refuses to build.

Deliberately commented out rather than deleted in order to make obvious that its omission is intentional.