### PR TITLE
[Reviewer: Rob] Misc fixes from live testing

### DIFF
--- a/include/memcached_backend.hpp
+++ b/include/memcached_backend.hpp
@@ -136,6 +136,20 @@ private:
                                       std::string& data,
                                       uint64_t& cas);
 
+  // Utility function to turn a return code from libmemcached back into a status
+  // code that can be used in the binary protocol.
+  //
+  // Note that libmemcached itself only converts a subset of memcache errors to
+  // distinct error codes. This is OK as the only errors we actually care about
+  // are KEY_NOT_FOUND, KEY_EXISTS and ITEM_NOT_STORED, which are a subset of
+  // the ones libmemcached copes with.  We convert everything else to
+  // TEMPORARY_FAILURE.
+  //
+  // @param rc - The memcached result code to convert.
+  // @return   - The corresponding memcache status code.
+  static Memcached::ResultCode
+    libmemcached_result_to_memcache_status(memcached_return_t rc);
+
   // Stores a pointer to an updater object
   Updater<void, MemcachedBackend>* _updater;
 

--- a/src/memcached_tap_client.cpp
+++ b/src/memcached_tap_client.cpp
@@ -250,7 +250,13 @@ Memcached::GetRsp::GetRsp(uint16_t status,
 std::string Memcached::GetRsp::generate_extra() const
 {
   std::string extras_string;
-  Utils::write(_flags, extras_string);
+
+  // Only add the flags if a result has been found.
+  if (_status == (uint16_t)ResultCode::NO_ERROR)
+  {
+    Utils::write(_flags, extras_string);
+  }
+
   return extras_string;
 }
 


### PR DESCRIPTION
A few miscellaneous fixes:

* Failed GETs should not have any flags. 
* If a key does not exist, a REPLACE fails with ITEM_NOT_STORED. Deletes can fail if the key does not exist (in the memcache protocol at least). Pass these return codes back to the user of astaire. 

Tested with dalli (a ruby memcahed client). 