### PR TITLE
[Reviewer: Andy] Allow a command-line argument to bind to a specific address

### DIFF
--- a/include/proxy_server.hpp
+++ b/include/proxy_server.hpp
@@ -48,7 +48,8 @@ public:
   /// Start the proxy server.
   ///
   /// @return - Whether the server started successfully or not.
-  bool start();
+  bool start(struct sockaddr* bind_addr = NULL);
+  bool start(const char* bind_addr);
 
 private:
   /// Entry points for the listener thread.
@@ -91,6 +92,7 @@ private:
   ///                     should be used for sending a response.
   void handle_delete(Memcached::DeleteReq* delete_req,
                      Memcached::ServerConnection* connection);
+
 
   /// Socket on which the server listens for new connections.
   int _listen_sock;

--- a/include/proxy_server.hpp
+++ b/include/proxy_server.hpp
@@ -48,7 +48,6 @@ public:
   /// Start the proxy server.
   ///
   /// @return - Whether the server started successfully or not.
-  bool start(struct sockaddr* bind_addr = NULL);
   bool start(const char* bind_addr);
 
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,7 @@ void usage(void)
        " --local-name <hostname>    Specify the name of the local memcached server\n"
        " --cluster-settings-file=<filename>\n"
        "                            The filename of the cluster settings file\n"
-       " --bind-addr=<IP>           The IP address to bid to (default: all)\n"
+       " --bind-addr=<IP>           The IP address to bind to (default: all)\n"
        " --log-file=<directory>     Log to file in specified directory\n"
        " --log-level=N              Set log level to N (default: 4)\n"
        " --pidfile=<filename>       Write pidfile\n"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ struct options
 {
   std::string local_memcached_server;
   std::string cluster_settings_file;
+  std::string bind_addr;
   bool log_to_file;
   std::string log_directory;
   int log_level;
@@ -61,6 +62,7 @@ enum Options
 {
   LOCAL_NAME=256+1,
   CLUSTER_SETTINGS_FILE,
+  BIND_ADDR,
   LOG_FILE,
   LOG_LEVEL,
   PIDFILE,
@@ -71,6 +73,7 @@ const static struct option long_opt[] =
 {
   {"local-name",             required_argument, NULL, LOCAL_NAME},
   {"cluster-settings-file",  required_argument, NULL, CLUSTER_SETTINGS_FILE},
+  {"bind-addr",              required_argument, NULL, BIND_ADDR},
   {"log-file",               required_argument, NULL, LOG_FILE},
   {"log-level",              required_argument, NULL, LOG_LEVEL},
   {"pidfile",                required_argument, NULL, PIDFILE},
@@ -87,6 +90,7 @@ void usage(void)
        " --local-name <hostname>    Specify the name of the local memcached server\n"
        " --cluster-settings-file=<filename>\n"
        "                            The filename of the cluster settings file\n"
+       " --bind-addr=<IP>           The IP address to bid to (default: all)\n"
        " --log-file=<directory>     Log to file in specified directory\n"
        " --log-level=N              Set log level to N (default: 4)\n"
        " --pidfile=<filename>       Write pidfile\n"
@@ -139,6 +143,10 @@ int init_options(int argc, char**argv, struct options& options)
 
     case CLUSTER_SETTINGS_FILE:
       options.cluster_settings_file = optarg;
+      break;
+
+    case BIND_ADDR:
+      options.bind_addr = optarg;
       break;
 
     case PIDFILE:
@@ -211,6 +219,7 @@ int main(int argc, char** argv)
   options.log_directory = "";
   options.local_memcached_server = "";
   options.cluster_settings_file = "";
+  options.bind_addr = "";
   options.pidfile = "";
 
   boost::filesystem::path p = argv[0];
@@ -304,7 +313,8 @@ int main(int argc, char** argv)
 
   // Start the memcached proxy server.
   ProxyServer* proxy_server = new ProxyServer(backend);
-  if (!proxy_server->start())
+  
+  if (!proxy_server->start(options.bind_addr.c_str()))
   {
     TRC_ERROR("Could not start proxy server, exiting");
     return 4;

--- a/src/proxy_server.cpp
+++ b/src/proxy_server.cpp
@@ -56,57 +56,39 @@ ProxyServer::~ProxyServer()
 
 bool ProxyServer::start(const char* bind_addr)
 {
+  int rc;
+  int sockaddr_size;
+  struct sockaddr_storage sa = {0};
+  struct sockaddr_in6* sa_in6 = (struct sockaddr_in6*)&sa;
+  struct sockaddr_in* sa_in = (struct sockaddr_in*)&sa;
+  uint16_t port = 11311;
+
   if (strlen(bind_addr) == 0)
   {
-    // If no bind address is given, just bind to all
-    return start();
+    // Set up the any address as a default
+    sa_in6->sin6_family = AF_INET6;
+    sa_in6->sin6_port = htons(port);
+    sockaddr_size = sizeof(sockaddr_in6);
+    rc = 1; // Success
   }
-
-  struct sockaddr sa = {0};
-
-  sa.sa_family = AF_INET;
-  int rc = inet_pton(AF_INET, bind_addr, &((struct sockaddr_in*)&(sa))->sin_addr);
-
-  if (rc != 1)
+  else if ((rc = inet_pton(AF_INET, bind_addr, &(sa_in->sin_addr))) == 1)
   {
-    // Try INET6 instead
-    sa.sa_family = AF_INET6;
-    rc = inet_pton(AF_INET6, bind_addr, &((struct sockaddr_in6*)&(sa))->sin6_addr);
+    sa_in->sin_family = AF_INET;
+    sa_in->sin_port = htons(port);
+    sockaddr_size = sizeof(sockaddr_in);
+  }
+  // If INET fails, try INET6 instead
+  else if ((rc = inet_pton(AF_INET6, bind_addr, &(sa_in6->sin6_addr))) == 1)
+  {
+    sa_in6->sin6_family = AF_INET6;
+    sa_in6->sin6_port = htons(port);
+    sockaddr_size = sizeof(sockaddr_in6);
   }
   
-  if (rc == 1)
-  {
-    return start(&sa);
-  }
-  else
+  if (rc != 1)
   {
     TRC_ERROR("Could not parse address '%s'", bind_addr);
     return false;
-  }
-}
-
-bool ProxyServer::start(struct sockaddr* bind_addr)
-{
-  int rc;
-  uint16_t port = 11311;
-    
-  // Set up the any address as a default
-  struct sockaddr_in6 any_addr = {0};
-  any_addr.sin6_family = AF_INET6;
-
-  if (bind_addr == NULL)
-  {
-    bind_addr = (struct sockaddr*)&any_addr;
-  }
-
-  // Bind to the specified port.
-  if (bind_addr->sa_family == AF_INET6)
-  {
-    ((struct sockaddr_in6*)bind_addr)->sin6_port = htons(port);
-  }
-  else if (bind_addr->sa_family == AF_INET)
-  {
-    ((struct sockaddr_in*)bind_addr)->sin_port = htons(port);
   }
 
   TRC_STATUS("Starting proxy server on port %d", port);
@@ -132,8 +114,9 @@ bool ProxyServer::start(struct sockaddr* bind_addr)
   }
 
   rc = bind(_listen_sock,
-            (struct sockaddr*)bind_addr,
-            sizeof(struct sockaddr));
+            (struct sockaddr*)&sa,
+            sockaddr_size);
+
   if (rc < 0)
   {
     TRC_ERROR("Could not bind listen socket: %d, %s", rc, strerror(errno));


### PR DESCRIPTION
Great fun to write, I love casting `struct sockaddr`s.

If Astaire gets passed `--bind-addr 127.0.0.2`, it should bind to just that address - if not, it should bind to the ANY address, as before.

I'll test this through clearwater-fv-test - both still listening on ANY by default, and that the specific address binding works. I might just do ad-hoc checking of that, though, rather than regressible checks.