### PR TITLE
[Reviewer: Rob] remove call to clear all alarms

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,7 +277,6 @@ int main(int argc, char** argv)
                                           AlarmDef::ASTAIRE_RESYNC_IN_PROGRESS,
                                           AlarmDef::MINOR);
   AlarmReqAgent::get_instance().start();
-  AlarmState::clear_all("astaire");
 
   // These values match those in MemcachedStore's constructor
   MemcachedStoreView* view = new MemcachedStoreView(128, 2);


### PR DESCRIPTION
Rob. I dont think it really needs reviewed, but just to check: are you happy for me to merge the other 1 line changes as below into their respective dev branches? 
I will also be removing the 'clear_all' method, so that any locations i miss will kill the builds.