### PR TITLE
[Reviewer: Rob] vBucket alarm modifications

### DIFF
--- a/include/memcached_backend.hpp
+++ b/include/memcached_backend.hpp
@@ -123,6 +123,12 @@ private:
   typedef enum {OK, FAILED} CommState;
   void update_vbucket_comm_state(int vbucket, CommState state);
 
+  // Stores time for the next vbucket alarm update. Start at 0 to ensure first update is sent
+  unsigned long _next_vbucket_alarm_update = 0;
+  unsigned long current_time_ms();
+  // Only send alarm updates if 30 seconds have passed since last update
+  unsigned int _update_period_ms = 30 * 1000;
+
   // Called by the thread-local-storage clean-up functions when a thread ends.
   static void cleanup_connection(void* p);
 

--- a/src/astaire.cpp
+++ b/src/astaire.cpp
@@ -195,6 +195,8 @@ void Astaire::control_thread()
     }
     else
     {
+      // Explicitly clear the resync alarm, in case it is still in unknown state.
+      _alarm->clear();
       // Wait 10s for the next resync trigger. If we don't get one in that time
       // we wake up and poll memcached again.
       TRC_DEBUG("Wait for resync trigger");

--- a/src/memcached_backend.cpp
+++ b/src/memcached_backend.cpp
@@ -303,6 +303,9 @@ const std::vector<memcached_st*>& MemcachedBackend::get_replicas(int vbucket,
 /// Update state of vbucket replica communication. If alarms are configured, a set
 /// alarm is issued if a vbucket becomes inaccessible, a clear alarm is issued once
 /// all vbuckets become accessible again.
+/// While _vbucket_comm_fail_count will essentially always be equal to the number of
+/// non-OK elements in _vbucket_comm_state, the comparison to 0 is much easier using
+/// an int rather than iterating over a map, so we maintain both.
 void MemcachedBackend::update_vbucket_comm_state(int vbucket, CommState state)
 {
   if (_vbucket_alarm)


### PR DESCRIPTION
This PR has the update to the vBucket alarm, to make it check if 30 seconds have passed since the last alarm update before re-sending alarm status. 
It also includes a line to explicitly clear the Astaire re-sync alarm.

(Commits made before comments on capitalisation :P) 