### PR TITLE
[Reviewer: None] Cope with Monit restrictions

### DIFF
--- a/root/usr/share/clearwater/infrastructure/scripts/check-astaire-uptime
+++ b/root/usr/share/clearwater/infrastructure/scripts/check-astaire-uptime
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-# @file astaire.monit
+# @file check-astaire-uptime
 #
 # Project Clearwater - IMS in the Cloud
-# Copyright (C) 2013  Metaswitch Networks Ltd
+# Copyright (C) 2016  Metaswitch Networks Ltd
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -34,31 +34,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-. /etc/clearwater/config
-
-# Set up the monit configuration for astaire
-cat > /etc/monit/conf.d/astaire.monit <<EOF
-# Monitor the server's PID file and check its memory usage.
-check process astaire_process pidfile /var/run/astaire/astaire.pid
-  group astaire
-
-  start program   = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 5500.3; /etc/init.d/astaire start'"
-  stop program    = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 5500.3; /etc/init.d/astaire stop'"
-  restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 5500.3; /etc/init.d/astaire restart'"
-
-  if memory is greater than 80% for 3 cycles
-     then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 5500.3; /etc/init.d/astaire abort-restart'"
-
-# Clear any alarms if the process has been running long enough.
-check program astaire_uptime with path /usr/share/clearwater/infrastructure/scripts/check-astaire-uptime
-  group astaire
-  depends on astaire_process
-  every 3 cycles
-  if status != 0 then alert
-
-EOF
-chmod 0644 /etc/monit/conf.d/astaire.monit
-
-# Force monit to reload its configuration
-reload clearwater-monit || true
-
+# Monit 5.8.1 does not support passing arguments to check program scripts.
+# check-uptime provides common uptime-checking code. This wrapper script
+# uses it, and can be called with no arguments.
+/usr/share/clearwater/bin/check-uptime /var/run/astaire/astaire.pid monit 5500.1


### PR DESCRIPTION
Monit can't pass arguments to check-program scripts in its current
version.