### PR TITLE
[Reviewer EM] Cap sync waits at 10 minutes so that scaling can complete

### DIFF
--- a/debian/astaire.init.d
+++ b/debian/astaire.init.d
@@ -210,7 +210,7 @@ do_wait_sync() {
 
                   if [ $num_conseq_unchanged -ge 120 ]
                   then
-                    logger astaire: Wait sync aborting as unsynced bucket count apparently stuck at $nodes
+                    logger astaire: Wait sync aborting as unsynced bucket count apparently stuck at $bucket_need_resync
                     break
                   fi
 

--- a/debian/astaire.init.d
+++ b/debian/astaire.init.d
@@ -180,7 +180,7 @@ do_wait_sync() {
 
         # Query astaire via the 0MQ socket, parse out the number of buckets
         # needing resync and check if it's 0.  If not, wait for 5s and try again.
-        num_conseq_unchanged=0
+        num_cycles_unchanged=0
         while true
         do
                 # Retrieve the statistics.
@@ -200,15 +200,15 @@ do_wait_sync() {
                 # If the number of buckets needing resync hasn't changed for the last 120 cycles (i.e.
                 # over the last 10 minutes), make a syslog and stop waiting.  We don't
                 # expect resyncs to take more than 10 minutes in normal operation, so this
-                # suggests that one or more of the remote nodes has failed.  We need to
+                # suggests that local service has failed  We need to
                 # end the wait in this case as the potential service impact of aborting
                 # the wait early is far outweighed by the impact on management operations
                 # of an infinite wait.
                 if [ "$bucket_need_resync" = "$last_bucket_need_resync" ]
                 then
-                  num_conseq_unchanged=$(( $num_conseq_unchanged + 1 ))
+                  num_cycles_unchanged=$(( $num_cycles_unchanged + 1 ))
 
-                  if [ $num_conseq_unchanged -ge 120 ]
+                  if [ $num_cycles_unchanged -ge 120 ]
                   then
                     logger astaire: Wait sync aborting as unsynced bucket count apparently stuck at $bucket_need_resync
                     break
@@ -216,7 +216,7 @@ do_wait_sync() {
 
                 else
                   last_bucket_need_resync=$bucket_need_resync
-                  num_conseq_unchanged=0
+                  num_cycles_unchanged=0
                 fi
 
                 # If we have numeric statistics, display them.


### PR DESCRIPTION
This is a change to the wait-sync command (see similar PR linked to this one from the chronos repo) to limit the time spent in a wait-sync loop if nothing is happening (i.e. the bucket count isn't changing).  This means that any operations blocked on the wait (such as scale in/out operations) are not blocked indefinitely due to, say, a failure of one of the remote nodes (which you cause the bucket count to eventually stick at a non-zero value).

A syslog message is written to indicate that the count is stuck.

Tested by running explicit wait-sync commands having hacked the script not to exit when the count reaches zero.