### PR TITLE
[Reviewer: Ellie] Suppress error log on memcached QUIT command

### DIFF
--- a/include/memcached_tap_client.hpp
+++ b/include/memcached_tap_client.hpp
@@ -90,6 +90,7 @@ namespace Memcached
     ADD = 0x02,
     REPLACE = 0x03,
     DELETE = 0x04,
+    QUIT = 0x07,
     VERSION = 0x0b,
     GETK = 0x0c,
     TAP_CONNECT = 0x40,

--- a/src/proxy_server.cpp
+++ b/src/proxy_server.cpp
@@ -283,6 +283,14 @@ void ProxyServer::connection_thread_fn(Memcached::ServerConnection* connection)
           }
           break;
 
+        case (uint8_t)Memcached::OpCode::QUIT:
+          {
+            //TRC_DEBUG("QUIT operation received");
+            TRC_DEBUG("QUIT operation received");
+            keep_going = false;
+          }
+          break;
+
         default:
           {
             TRC_WARNING("Unrecognized operation: %d", req->op_code());

--- a/src/proxy_server.cpp
+++ b/src/proxy_server.cpp
@@ -285,7 +285,6 @@ void ProxyServer::connection_thread_fn(Memcached::ServerConnection* connection)
 
         case (uint8_t)Memcached::OpCode::QUIT:
           {
-            //TRC_DEBUG("QUIT operation received");
             TRC_DEBUG("QUIT operation received");
             keep_going = false;
           }


### PR DESCRIPTION
Fixed issue #72 

Just make a DEBUG log to suppress the warning. By setting keep_going false, we'll delete the connection anyway, so the only change is to the logging.

Testing:
 - live tested (you need a split-clusters style sprout to connect to Astaire as a memcached proxy, and then quiescing the sprout will send a QUIT command)