### PR TITLE
[Reviewer: Seb] Install monit script by restarting infrastructure

### DIFF
--- a/debian/astaire.postinst
+++ b/debian/astaire.postinst
@@ -92,7 +92,7 @@ case "$1" in
         # running (though it does return non-0 in this scenario).
         start astaire-throttle || /bin/true
 
-        /usr/share/clearwater/infrastructure/scripts/astaire.monit
+        invoke-rc.d clearwater-infrastructure restart
 
         # Restart astaire.  Always do this by terminating astaire so monit will
         # restart it more-or-less immediately.  (monit restart seems to have


### PR DESCRIPTION
This matches what we do elsewhere (restarting clearwater-infrastructure), and resolves problems
with config not being available.

We use invoke-rc.d as we are in a post-install script, and this checks policy regarding what services shoudl be started, which allows us to prevent services being started using policy.