### PR TITLE
[Reviewer: Seb] Fix Boost Regex Linker Error

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,7 @@ astaire_LDFLAGS := -L../usr/lib \
                    -lmemcached \
                    -lpthread \
                    -lboost_filesystem \
+                   -lboost_regex \
                    -lboost_system \
                    -lrt \
                    -lzmq


### PR DESCRIPTION
Seb,

Simple fix - https://github.com/Metaswitch/cpp-common/pull/680 adds a requirement on linking to boost_regex.