### PR TITLE
[Reviewer: Adam] Astaire memory leak

### DIFF
--- a/src/proxy_server.cpp
+++ b/src/proxy_server.cpp
@@ -195,6 +195,7 @@ void ProxyServer::listen_thread_fn()
         // Couldn't create a thread to handle this connection. Just close it.
         TRC_WARNING("Could not create per-connection thread: %d", rc);
         delete connection; connection = NULL;
+        delete params; params = NULL;
       }
     }
   }

--- a/src/proxy_server.cpp
+++ b/src/proxy_server.cpp
@@ -178,9 +178,16 @@ void ProxyServer::listen_thread_fn()
       params->server = this;
       params->connection = connection;
 
+      // We never join() these threads once they're created, so we must create
+      // them as detached rather than joinable to allow the system to free up
+      // the thread's resources once it has terminated
+      pthread_attr_t tattr;
+      pthread_attr_init(&tattr);
+      pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_DETACHED);
+
       pthread_t tid;
       int rc = pthread_create(&tid,
-                              NULL,
+                              &tattr,
                               connection_thread_entry_point,
                               params);
       if (rc < 0)


### PR DESCRIPTION
I spotted that if Astaire was unable to contact any memcached processes while load was running through the system, Astaire's memory usage started rising continuously and didn't fall back down once memcached was restarted.

After some digging, it turned out that Astaire creates its proxy threads in state `joinable`. When a thread is created in this state, the system won't clear up the thread resources until `join()` is called on the thread, even if the thread has already terminated.

We never call `join()` on these threads, as they're just created to handle a single connection and then left to terminate once that connection is closed.

This means that we were leaking memory with every thread that terminated. Under mainline operation, we expect that these threads will persist for a while because the clients (Sprout, Ralf and Homestead) reuse their memcached connections, and there's one thread per memcached connection. We saw the memory increase when memcached wasn't contactable because the clients disconnect on error, which the Astaire threads notice and which causes them to terminate.

The fix is to create the threads in `detached` state, which is the alternative to `joinable`. In this state, `join()` cannot be called on the thread, and resources are freed once the thread terminates. (Basically, threads should either be joinable and have join called on them, or be detached and not have it called.)

#### Testing
Tested by running load through Astaire and killing memcached while watching the Astaire process's memory usage in `top`:
* before this fix, I saw the memory usage increase continuously (in this case from 0.3% to 2% in about 10 seconds)
* after this fix, I saw the memory usage stay at 0.3% over the same ~10s period