### PR TITLE
Don't overflow on large messages

### DIFF
--- a/include/memcached_tap_client.hpp
+++ b/include/memcached_tap_client.hpp
@@ -463,7 +463,7 @@ namespace Memcached
   // Parsing utility fuctions.
   bool is_msg_complete(const std::string& msg,
                        bool& request,
-                       uint16_t& body_length,
+                       uint32_t& body_length,
                        uint8_t& op_code);
   template <class T> BaseMessage* from_wire_int(const std::string& msg)
   {

--- a/src/memcached_tap_client.cpp
+++ b/src/memcached_tap_client.cpp
@@ -107,7 +107,6 @@ bool Memcached::from_wire(std::string& msg,
       break;
     }
   }
-
   else
   {
     switch (op_code)

--- a/src/memcached_tap_client.cpp
+++ b/src/memcached_tap_client.cpp
@@ -26,7 +26,7 @@ void Memcached::Utils::write(const std::string& str, std::string& ss)
 
 bool Memcached::is_msg_complete(const std::string& msg,
                                 bool& request,
-                                uint16_t& body_length,
+                                uint32_t& body_length,
                                 uint8_t& op_code)
 {
   uint32_t raw_length = msg.length();
@@ -67,7 +67,7 @@ bool Memcached::from_wire(std::string& msg,
                           Memcached::BaseMessage*& output)
 {
   bool request;
-  uint16_t body_length;
+  uint32_t body_length;
   uint8_t op_code;
 
   if (!is_msg_complete(msg, request, body_length, op_code))
@@ -107,6 +107,7 @@ bool Memcached::from_wire(std::string& msg,
       break;
     }
   }
+
   else
   {
     switch (op_code)


### PR DESCRIPTION
See description in https://github.com/Metaswitch/cpp-common/pull/703.

Like it says.   Astaire doesn't have any UTs, but I've tested live.   

We don't think there are ever legitimate use cases where we need to store more than 64k of data, but there are currently cases where we will try to store more than this -- e.g. IMPI data can grow arbitrarily large if a sub sends in lots of rapid REGISTERs that get challenged.

I thought about enforcing a request size limit in Astaire, but since there is no such limit in memcached this didn't feel right.   Instead I've added a limit on the client side (memcachedstore).   See https://github.com/Metaswitch/cpp-common/pull/703