### PR TITLE
Make timeout half the length of that used by Sprout / Homestead ...

### DIFF
--- a/src/memcached_backend.cpp
+++ b/src/memcached_backend.cpp
@@ -58,7 +58,7 @@ MemcachedBackend::MemcachedBackend(MemcachedConfigReader* config_reader,
   // timeout because libmemcached tries to connect to all servers sequentially
   // during start-up, and if any are not up we don't want to wait for any
   // significant length of time.
-  _options = "--CONNECT-TIMEOUT=10 --SUPPORT-CAS --POLL-TIMEOUT=250 --BINARY-PROTOCOL";
+  _options = "--CONNECT-TIMEOUT=10 --SUPPORT-CAS --POLL-TIMEOUT=50 --BINARY-PROTOCOL";
 
   // Create an updater to keep the store configured appropriately.
   _updater = new Updater<void, MemcachedBackend>(this, std::mem_fun(&MemcachedBackend::update_config));


### PR DESCRIPTION
… to allow time to query the second replica if the first times out.

This (along with related PRs below) fixes: https://github.com/Metaswitch/clearwater-issues/issues/2681 and related issues.   See discussion in that issue for the cause of the problem.

