### PR TITLE
Add more error logs to failing to read or write data

### DIFF
--- a/src/memcached_backend.cpp
+++ b/src/memcached_backend.cpp
@@ -324,8 +324,12 @@ Memcached::ResultCode MemcachedBackend::read_data(const std::string& key,
     else
     {
       // Error from this node, so consider it inactive.
-      TRC_DEBUG("Read for %s on replica %d returned error %d (%s)",
-                key.c_str(), replica_idx, rc, memcached_strerror(conn, rc));
+      TRC_ERROR("Read for %s on replica %d (%s) returned error %d (%s)",
+                key.c_str(),
+                replica_idx,
+                replica_addresses[replica_idx].address_and_port_to_string().c_str(),
+                rc,
+                memcached_strerror(conn, rc));
       ++failed_replicas;
     }
   }
@@ -370,16 +374,14 @@ Memcached::ResultCode MemcachedBackend::read_data(const std::string& key,
   {
     // All replicas returned an error, so log the error and return the
     // failure.
-    TRC_ERROR("Failed to read data for %s from %d replicas",
-              key.c_str(), replica_addresses.size());
-
     std::string ip_string;
-    for (size_t iii = 0; iii < replica_addresses.size(); ++iii)
+    for (AddrInfo replica: replica_addresses)
     {
-      ip_string += " \n";
-      ip_string += replica_addresses[iii].address_and_port_to_string();
+      ip_string += replica.address_and_port_to_string();
+      ip_string += ", ";
     }
-    TRC_ERROR("Failed to read from: %s", ip_string.c_str());
+    TRC_ERROR("Failed to read data for %s from %d replicas (%s)",
+              key.c_str(), replica_addresses.size(), ip_string.c_str());
 
     status = Memcached::ResultCode::TEMPORARY_FAILURE;
 
@@ -536,9 +538,19 @@ Memcached::ResultCode MemcachedBackend::write_data(Memcached::OpCode operation,
       // A NOT_FOUND, NOT_STORED or EXISTS response indicates a concurrent write
       // failure, so return this to the application immediately - don't go on to
       // other replicas.
-      TRC_INFO("Contention writing data for %s to store", key.c_str());
+      TRC_WARNING("Contention writing data for %s to store", key.c_str());
       status = libmemcached_result_to_memcache_status(rc);
       break;
+    }
+    else
+    {
+      TRC_ERROR("Conditional write (opcode %d) for %s failed to replica %d (%s) with error %d (%s)",
+                operation,
+                key.c_str(),
+                replica_idx,
+                replica_addresses[replica_idx].address_and_port_to_string().c_str(),
+                rc,
+                memcached_strerror(conn, rc));
     }
   }
 
@@ -579,15 +591,14 @@ Memcached::ResultCode MemcachedBackend::write_data(Memcached::OpCode operation,
       _comm_monitor->inform_failure();
     }
 
-    TRC_ERROR("Failed to write data for %s to %d replicas",
-              key.c_str(), replica_addresses.size());
     std::string ip_string;
-    for (size_t iii = 0; iii < replica_addresses.size(); ++iii)
+    for (AddrInfo replica: replica_addresses)
     {
-      ip_string += " \n";
-      ip_string += replica_addresses[iii].address_and_port_to_string();
+      ip_string += replica.address_and_port_to_string();
+      ip_string += ", ";
     }
-    TRC_ERROR("Failed to write to: %s", ip_string.c_str());
+    TRC_ERROR("Failed to write data for %s to %d replicas (%s)",
+              key.c_str(), replica_addresses.size(), ip_string.c_str());
 
     status = Memcached::ResultCode::TEMPORARY_FAILURE;
   }
@@ -636,7 +647,13 @@ Memcached::ResultCode MemcachedBackend::delete_data(const std::string& key)
 
     if (!memcached_success(rc))
     {
-      TRC_ERROR("Delete failed to replica %d", ii);
+      TRC_ERROR("Delete for %s failed to replica %d (%s) with error %d (%s)",
+                key.c_str(),
+                ii,
+                replica_addresses[ii].address_and_port_to_string().c_str(),
+                rc,
+                memcached_strerror(conn, rc));
+ 
 
       if (best_status != Memcached::ResultCode::NO_ERROR)
       {

--- a/src/memcached_backend.cpp
+++ b/src/memcached_backend.cpp
@@ -373,6 +373,14 @@ Memcached::ResultCode MemcachedBackend::read_data(const std::string& key,
     TRC_ERROR("Failed to read data for %s from %d replicas",
               key.c_str(), replica_addresses.size());
 
+    std::string ip_string;
+    for (size_t iii = 0; iii < replica_addresses.size(); ++iii)
+    {
+      ip_string += " \n";
+      ip_string += replica_addresses[iii].address_and_port_to_string();
+    }
+    TRC_ERROR("Failed to read from: %s", ip_string.c_str());
+
     status = Memcached::ResultCode::TEMPORARY_FAILURE;
 
     update_vbucket_comm_state(vbucket, FAILED);
@@ -573,6 +581,13 @@ Memcached::ResultCode MemcachedBackend::write_data(Memcached::OpCode operation,
 
     TRC_ERROR("Failed to write data for %s to %d replicas",
               key.c_str(), replica_addresses.size());
+    std::string ip_string;
+    for (size_t iii = 0; iii < replica_addresses.size(); ++iii)
+    {
+      ip_string += " \n";
+      ip_string += replica_addresses[iii].address_and_port_to_string();
+    }
+    TRC_ERROR("Failed to write to: %s", ip_string.c_str());
 
     status = Memcached::ResultCode::TEMPORARY_FAILURE;
   }


### PR DESCRIPTION
Adds additional error logs to say which IP addresses the failing memcached where from with read or write. I have run the live tests in Clearwater-fv-test but have done no live testing.